### PR TITLE
Fix typo in link to strong-authn-settings-4.2.0

### DIFF
--- a/docs/source/plugins/2fa-settings.md
+++ b/docs/source/plugins/2fa-settings.md
@@ -43,7 +43,7 @@ A device/location is considered trustworthy when the user has presented a strong
     
 ## Installation
 
-1. [Download the plugin](https://ox.gluu.org/maven/org/gluu/casa/plugins/strong-authn-settings/4.2.Final/strong-authn-settings-4.2.Final-jar-with-dependencies.jar)
+1. [Download the plugin](https://ox.gluu.org/maven/org/gluu/casa/plugins/strong-authn-settings/4.2.0.Final/strong-authn-settings-4.2.0.Final-jar-with-dependencies.jar)
 
 1. Log in to Casa using an administrator account
 


### PR DESCRIPTION
Updates download link to the strong-authn-settings-4.2.0 plugin.

* fixes 404 error